### PR TITLE
added role selection menu for when user lands on active game page

### DIFF
--- a/app/Components/App.js
+++ b/app/Components/App.js
@@ -35,15 +35,14 @@ class App extends React.Component {
     }
   }
 
-  createGame(e) {
-    e.preventDefault();
+  createGame() {
     socket.emit("newgame");
   }
 
   render() {
     return (
       <div>
-        <button onClick={this.createGame}> Create New Game </button>
+        <button onClick={() => this.createGame()}> Create New Game as Student </button>
         <form onSubmit={this.joinGame} className="MyForm">
           <input type="text" value={this.state.value} onChange={this.handleChange}/>
           <input type="submit" value="Join Game"/>

--- a/app/Components/ChatApp.js
+++ b/app/Components/ChatApp.js
@@ -2,8 +2,6 @@ import React from 'react';
 import MessageList from './MessageList';
 import MessageForm from './MessageForm';
 
-
-
 class ChatApp extends React.Component {
 
   constructor(props) {

--- a/app/Components/Game/index.js
+++ b/app/Components/Game/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ChatApp from '../ChatApp';
 import Profile from '../Profile';
 import Quiz from '../Quiz';
+import RoleSelectionMenu from '../RoleSelectionMenu';
 
 import io from 'socket.io-client';
 let socket = io.connect('');
@@ -9,33 +10,71 @@ let socket = io.connect('');
 class Game extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {at_capacity: false, role: null, round_over: false, is_active_game: false};
+    this.state = {at_capacity: false, role: null, round_over: false, is_active_game: false, takenRoles: null};
     socket.on('connect', () => this._connect());
     socket.on('init', (username) =>this._initialize(username));
     socket.on('getroom', () => this._get_room());
     socket.on('adduser', (user_role) => this._add_user(user_role));
     socket.on('fullhouse', () => this._full_house());
-    socket.on('isgameID', (flag) => this._is_game_ID(flag));
+    socket.on('isgameID', (flag, takenRoles) => this._is_game_ID(flag, takenRoles));
+    this.setRoleOptions = this.setRoleOptions.bind(this);
+    this.selectRole = this.selectRole.bind(this);
   }
 
   componentDidMount() {
-    // socket.emit('setroom', this.props.params.gameID);
+    console.log("componentDidMount");
+    console.log(this.props.params.gameID);
     socket.emit('joingame', this.props.params.gameID);
   }
 
-  _connect() {
-    socket.emit('setroom', this.props.params.gameID);
+  _connect(takenRoles) { // not called anymore 
+    
+    if (this.state.is_active_game) {
+      
+      // socket.emit('setrole');
+      socket.emit('setroom', this.props.params.gameID);
+    }
+  }
+
+  setRoleOptions(takenRoles) {
+    // var takenRoles = this.props.takenRoles;
+    var studentDisabled = false;
+    var teacherDisabled = false;
+    if (takenRoles.length == 2) {
+
+      studentDisabled = true;
+      teacherDisabled = true;
+    } else if (takenRoles.length == 1) {
+      if (takenRoles[0] == "student") {
+        studentDisabled = true;
+      } else {
+        teacherDisabled = true;
+      }
+    }
+    return(
+      <RoleSelectionMenu 
+        socket={socket} 
+        takenRoles={this.state.takenRoles} 
+        selectRole={this.selectRole}
+        gameID={this.props.params.gameID}
+        studentDisabled={studentDisabled}
+        teacherDisabled={teacherDisabled}/>
+    )
   }
 
   _initialize(username) {
     this.setState({user: username});
   }
 
-  _is_game_ID(flag) {
-    this.setState({is_active_game: flag});
+  _is_game_ID(flag, takenRoles) {
+    console.log("taken roles");
+    console.log(takenRoles)
+    
     if (flag) {
-      this._connect();
+      this.setState({takenRoles: takenRoles});
+      // this._connect(takenRoles);
     }
+    this.setState({is_active_game: flag});
   }
 
   _add_user(user_role) {
@@ -55,11 +94,22 @@ class Game extends React.Component {
     this.setState({round_over: true});
   }
 
+  selectRole(role) {
+    this.setState({role: role});
+  }
+
   render() {
     if (!this.state.is_active_game) {
+      console.log("not an active game");
       return (
         <h1> This page does not exit </h1>
       );
+    } else if (this.state.role==null) { // role hasn't been set yet
+      console.log("no roles exist")
+      return(
+        this.setRoleOptions(this.state.takenRoles)
+      );
+      
     }
     if (this.state.at_capacity) {
       return (

--- a/app/Components/Game/index.js
+++ b/app/Components/Game/index.js
@@ -11,8 +11,8 @@ class Game extends React.Component {
   constructor(props) {
     super(props);
     this.state = {at_capacity: false, role: null, round_over: false, is_active_game: false, takenRoles: null};
-    socket.on('connect', () => this._connect());
-    socket.on('init', (username) =>this._initialize(username));
+    // socket.on('connect', () => this._connect());
+    // socket.on('init', (username) =>this._initialize(username));
     socket.on('getroom', () => this._get_room());
     socket.on('adduser', (user_role) => this._add_user(user_role));
     socket.on('fullhouse', () => this._full_house());
@@ -22,19 +22,14 @@ class Game extends React.Component {
   }
 
   componentDidMount() {
-    console.log("componentDidMount");
-    console.log(this.props.params.gameID);
     socket.emit('joingame', this.props.params.gameID);
   }
 
-  _connect(takenRoles) { // not called anymore 
-    
-    if (this.state.is_active_game) {
-      
-      // socket.emit('setrole');
-      socket.emit('setroom', this.props.params.gameID);
-    }
-  }
+  // _connect(takenRoles) { // not called anymore 
+  //   if (this.state.is_active_game) {
+  //     socket.emit('setroom', this.props.params.gameID);
+  //   }
+  // }
 
   setRoleOptions(takenRoles) {
     // var takenRoles = this.props.takenRoles;
@@ -59,28 +54,24 @@ class Game extends React.Component {
         gameID={this.props.params.gameID}
         studentDisabled={studentDisabled}
         teacherDisabled={teacherDisabled}/>
-    )
+    );
   }
 
-  _initialize(username) {
-    this.setState({user: username});
-  }
+  // _initialize(username) {
+  //   this.setState({user: username});
+  // }
 
   _is_game_ID(flag, takenRoles) {
-    console.log("taken roles");
-    console.log(takenRoles)
     
     if (flag) {
       this.setState({takenRoles: takenRoles});
-      // this._connect(takenRoles);
     }
     this.setState({is_active_game: flag});
   }
 
-  _add_user(user_role) {
-    this.setState({role: user_role});
-    socket.emit('adduser', prompt("What's your name?"));
-  }
+  // _add_user(user_role) {
+  //   socket.emit('adduser', prompt("What's your name?"));
+  // }
  
   _get_room() {
     socket.emit('setroom', this.props.params.gameID);
@@ -100,12 +91,10 @@ class Game extends React.Component {
 
   render() {
     if (!this.state.is_active_game) {
-      console.log("not an active game");
       return (
         <h1> This page does not exit </h1>
       );
     } else if (this.state.role==null) { // role hasn't been set yet
-      console.log("no roles exist")
       return(
         this.setRoleOptions(this.state.takenRoles)
       );
@@ -120,7 +109,7 @@ class Game extends React.Component {
         <div >
           <div style={{display:'flex', flexDirection:'row'}}>
             <div style={{flex:1}}>
-              <ChatApp socket={socket} user={this.state.user}/>
+              <ChatApp socket={socket} user={this.state.role}/>
             </div>
             <div style={{flex:1}}>
               <Profile role={this.state.role} profile_data={this.props.route.bundle[this.state.role]} />

--- a/app/Components/Game/index.js
+++ b/app/Components/Game/index.js
@@ -3,7 +3,6 @@ import ChatApp from '../ChatApp';
 import Profile from '../Profile';
 import Quiz from '../Quiz';
 import RoleSelectionMenu from '../RoleSelectionMenu';
-
 import io from 'socket.io-client';
 let socket = io.connect('');
  
@@ -11,11 +10,6 @@ class Game extends React.Component {
   constructor(props) {
     super(props);
     this.state = {at_capacity: false, role: null, round_over: false, is_active_game: false, takenRoles: null};
-    // socket.on('connect', () => this._connect());
-    // socket.on('init', (username) =>this._initialize(username));
-    socket.on('getroom', () => this._get_room());
-    socket.on('adduser', (user_role) => this._add_user(user_role));
-    socket.on('fullhouse', () => this._full_house());
     socket.on('isgameID', (flag, takenRoles) => this._is_game_ID(flag, takenRoles));
     this.setRoleOptions = this.setRoleOptions.bind(this);
     this.selectRole = this.selectRole.bind(this);
@@ -25,18 +19,10 @@ class Game extends React.Component {
     socket.emit('joingame', this.props.params.gameID);
   }
 
-  // _connect(takenRoles) { // not called anymore 
-  //   if (this.state.is_active_game) {
-  //     socket.emit('setroom', this.props.params.gameID);
-  //   }
-  // }
-
   setRoleOptions(takenRoles) {
-    // var takenRoles = this.props.takenRoles;
     var studentDisabled = false;
     var teacherDisabled = false;
     if (takenRoles.length == 2) {
-
       studentDisabled = true;
       teacherDisabled = true;
     } else if (takenRoles.length == 1) {
@@ -57,28 +43,11 @@ class Game extends React.Component {
     );
   }
 
-  // _initialize(username) {
-  //   this.setState({user: username});
-  // }
-
   _is_game_ID(flag, takenRoles) {
-    
     if (flag) {
       this.setState({takenRoles: takenRoles});
     }
     this.setState({is_active_game: flag});
-  }
-
-  // _add_user(user_role) {
-  //   socket.emit('adduser', prompt("What's your name?"));
-  // }
- 
-  _get_room() {
-    socket.emit('setroom', this.props.params.gameID);
-  }
-
-  _full_house() {
-    this.setState({at_capacity: true});
   }
 
   round_over() {
@@ -94,11 +63,10 @@ class Game extends React.Component {
       return (
         <h1> This page does not exit </h1>
       );
-    } else if (this.state.role==null) { // role hasn't been set yet
+    } else if (this.state.role==null) {
       return(
         this.setRoleOptions(this.state.takenRoles)
       );
-      
     }
     if (this.state.at_capacity) {
       return (

--- a/app/Components/RoleSelectionMenu.js
+++ b/app/Components/RoleSelectionMenu.js
@@ -6,7 +6,6 @@ class RoleSelectionMenu extends React.Component {
     this.state = {selectedRole: null, studentDisabled: false, teacherDisabled: false};
     this.handleOptionChange = this.handleOptionChange.bind(this);
     this.handleFormSubmit = this.handleFormSubmit.bind(this);
-    // this.setOptions = this.setOptions.bind(this);
   }
 
   handleOptionChange(changeEvent) {
@@ -17,21 +16,11 @@ class RoleSelectionMenu extends React.Component {
 
   handleFormSubmit(formSubmitEvent) {
     formSubmitEvent.preventDefault();
-    console.log("setrole called from RoleSelectionMenu");
-    console.log("gameID type");
-    console.log(typeof this.props.gameID)
-    console.log("this.props.gameID" + this.props.gameID);
     this.props.socket.emit('settingrole', this.state.selectedRole, this.props.gameID);
     this.props.selectRole(this.state.selectedRole);
-    console.log('You have selected:', this.state.selectedRole);
   }
 
-  
-
   render() {
-    // set options 
-    console.log(this.props.takenRoles);
-    // this.setOptions();
     return (
       <form onSubmit={this.handleFormSubmit}>
         <label>

--- a/app/Components/RoleSelectionMenu.js
+++ b/app/Components/RoleSelectionMenu.js
@@ -1,0 +1,76 @@
+import React from 'react';
+
+class RoleSelectionMenu extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {selectedRole: null, studentDisabled: false, teacherDisabled: false};
+    this.handleOptionChange = this.handleOptionChange.bind(this);
+    this.handleFormSubmit = this.handleFormSubmit.bind(this);
+    // this.setOptions = this.setOptions.bind(this);
+  }
+
+  handleOptionChange(changeEvent) {
+    this.setState({
+      selectedRole: changeEvent.target.value
+    });
+  }
+
+  handleFormSubmit(formSubmitEvent) {
+    formSubmitEvent.preventDefault();
+    console.log("setrole called from RoleSelectionMenu");
+    console.log("gameID type");
+    console.log(typeof this.props.gameID)
+    console.log("this.props.gameID" + this.props.gameID);
+    this.props.socket.emit('settingrole', this.state.selectedRole, this.props.gameID);
+    this.props.selectRole(this.state.selectedRole);
+    console.log('You have selected:', this.state.selectedRole);
+  }
+
+  
+
+  render() {
+    // set options 
+    console.log(this.props.takenRoles);
+    // this.setOptions();
+    return (
+      <form onSubmit={this.handleFormSubmit}>
+        <label>
+          <input type="radio" 
+            value="student" 
+            checked={this.state.selectedRole === 'student' } 
+            onChange={this.handleOptionChange} 
+            disabled={this.props.studentDisabled}/>
+          Student
+        </label>
+        <label>
+          <input type="radio" 
+            value="teacher" 
+            checked={this.state.selectedRole === 'teacher'} 
+            onChange={this.handleOptionChange} 
+            disabled={this.props.teacherDisabled}/>
+          Teacher
+        </label>
+        <label>
+          <input 
+            type="radio" 
+            value="observer"
+            checked={this.state.selectedRole === 'observer'} 
+            onChange={this.handleOptionChange} />
+          Observer
+        </label>
+        <button className="btn btn-default" type="submit">Enter Game</button>
+      </form>
+    );
+  }
+}
+
+RoleSelectionMenu.propTypes = {
+  takenRoles: React.PropTypes.array,
+  socket: React.PropTypes.object,
+  selectRole: React.PropTypes.func,
+  gameID: React.PropTypes.string,
+  studentDisabled: React.PropTypes.bool,
+  teacherDisabled: React.PropTypes.bool
+};
+
+export default RoleSelectionMenu;

--- a/server.js
+++ b/server.js
@@ -45,51 +45,48 @@ io.on('connection', function (socket) {
       gameID = Math.round((Math.random()*10000));
     }
     gameIDs[gameID] = {};
-    console.log(gameIDs);
     socket.emit('assigngameID', gameID);
   });
 
   var takenRoles = null;
   socket.on('joingame', function(gameID) {
     var isGameID = gameID in gameIDs;
-    console.log(isGameID);
     if (isGameID) {
       takenRoles = Object.keys(gameIDs[gameID]);
     }
-    console.log(takenRoles);
     socket.emit('isgameID', isGameID, takenRoles);
   });
 
   // sets role from RoleSelectionMenu
   socket.on('settingrole', function(selectedRole, gameID) {
-    console.log("selectedRole" + selectedRole);
-    console.log("gameID" + gameID);
     if (selectedRole!="observer") {
-      console.log("selectedRole: " + selectedRole);
-      console.log(gameIDs);
-      // console
-      console.log(gameIDs[gameID]);
       gameIDs[gameID][selectedRole] = null;
-      console.log(gameIDs);
+      socket.room = gameID;
+      console.log(gameID);
+      socket.username = selectedRole;
+      socket.join(socket.room);
+      socket.emit('updatechat', { user: 'SERVER', text: 'you have connected to game ' + socket.room });
+      socket.broadcast.to(socket.room).emit('updatechat', { user: 'SERVER', text: socket.username + ' has connected to this room' });
+      // socket.emit('init', socket.username);
     }
   });
 
-  // communicates with Game 
-  socket.on('setroom', function(roomID) {
-    socket.room = "room " + roomID;
-    if (roomID in data) { // room has been entered before 
-      if (data[roomID]["atCapacity"]) {
-        socket.emit('fullhouse');
-      } else {
-        data[roomID]["student"] = socket.username;
-        data[roomID]["atCapacity"] = true;
-        socket.emit('adduser','student'); // student + teacher are currently undefined 
-      }
-    } else {
-      data[roomID] = {"atCapacity": false, "teacher": socket.username};
-      socket.emit('adduser', 'teacher');
-    }
-  });
+  // // communicates with Game 
+  // socket.on('setroom', function(roomID) {
+  //   // socket.room = "room " + roomID;
+  //   (rooif mID in data) { // room has been entered before 
+  //     if (data[roomID]["atCapacity"]) {
+  //       socket.emit('fullhouse');
+  //     } else {
+  //       data[roomID]["student"] = socket.username;
+  //       data[roomID]["atCapacity"] = true;
+  //       socket.emit('adduser','student'); // student + teacher are currently undefined 
+  //     }
+  //   } else {
+  //     data[roomID] = {"atCapacity": false, "teacher": socket.username};
+  //     socket.emit('adduser', 'teacher');
+  //   }
+  // });
 
   // when the client emits 'adduser', this listens and executes
   socket.on('adduser', function(username){
@@ -97,7 +94,7 @@ io.on('connection', function (socket) {
     socket.username = username;
     // store the room name in the socket session for this client
     // add the client's username to the global list
-    usernames[username] = username;
+    // usernames[username] = username;
     // send client to room 1
     socket.join(socket.room);
     socket.emit('updatechat', { user: 'SERVER', text: 'you have connected to ' + socket.room });

--- a/server.js
+++ b/server.js
@@ -34,7 +34,6 @@ server.listen(port);
 
 // usernames which are currently connected to the chat
 var usernames = {};
-var data = {};
 var gameIDs = {};
 
 io.on('connection', function (socket) {
@@ -62,46 +61,12 @@ io.on('connection', function (socket) {
     if (selectedRole!="observer") {
       gameIDs[gameID][selectedRole] = null;
       socket.room = gameID;
-      console.log(gameID);
       socket.username = selectedRole;
       socket.join(socket.room);
       socket.emit('updatechat', { user: 'SERVER', text: 'you have connected to game ' + socket.room });
       socket.broadcast.to(socket.room).emit('updatechat', { user: 'SERVER', text: socket.username + ' has connected to this room' });
-      // socket.emit('init', socket.username);
     }
   });
-
-  // // communicates with Game 
-  // socket.on('setroom', function(roomID) {
-  //   // socket.room = "room " + roomID;
-  //   (rooif mID in data) { // room has been entered before 
-  //     if (data[roomID]["atCapacity"]) {
-  //       socket.emit('fullhouse');
-  //     } else {
-  //       data[roomID]["student"] = socket.username;
-  //       data[roomID]["atCapacity"] = true;
-  //       socket.emit('adduser','student'); // student + teacher are currently undefined 
-  //     }
-  //   } else {
-  //     data[roomID] = {"atCapacity": false, "teacher": socket.username};
-  //     socket.emit('adduser', 'teacher');
-  //   }
-  // });
-
-  // when the client emits 'adduser', this listens and executes
-  socket.on('adduser', function(username){
-    // store the username in the socket session for this client
-    socket.username = username;
-    // store the room name in the socket session for this client
-    // add the client's username to the global list
-    // usernames[username] = username;
-    // send client to room 1
-    socket.join(socket.room);
-    socket.emit('updatechat', { user: 'SERVER', text: 'you have connected to ' + socket.room });
-    socket.broadcast.to(socket.room).emit('updatechat', { user: 'SERVER', text: username + ' has connected to this room' });
-    socket.emit('init', socket.username);
-  });
-
 
   // when the client emits 'sendchat', this listens and executes
   socket.on('sendchat', function (data) {

--- a/server.js
+++ b/server.js
@@ -35,7 +35,7 @@ server.listen(port);
 // usernames which are currently connected to the chat
 var usernames = {};
 var data = {};
-var gameIDs = new Set();
+var gameIDs = {};
 
 io.on('connection', function (socket) {
   // create a new game from app.js
@@ -44,16 +44,39 @@ io.on('connection', function (socket) {
     while (gameID in gameIDs) {
       gameID = Math.round((Math.random()*10000));
     }
-    gameIDs.add(gameID);
+    gameIDs[gameID] = {};
+    console.log(gameIDs);
     socket.emit('assigngameID', gameID);
   });
 
+  var takenRoles = null;
   socket.on('joingame', function(gameID) {
-    socket.emit('isgameID', gameIDs.has(parseInt(gameID)));
+    var isGameID = gameID in gameIDs;
+    console.log(isGameID);
+    if (isGameID) {
+      takenRoles = Object.keys(gameIDs[gameID]);
+    }
+    console.log(takenRoles);
+    socket.emit('isgameID', isGameID, takenRoles);
   });
 
+  // sets role from RoleSelectionMenu
+  socket.on('settingrole', function(selectedRole, gameID) {
+    console.log("selectedRole" + selectedRole);
+    console.log("gameID" + gameID);
+    if (selectedRole!="observer") {
+      console.log("selectedRole: " + selectedRole);
+      console.log(gameIDs);
+      // console
+      console.log(gameIDs[gameID]);
+      gameIDs[gameID][selectedRole] = null;
+      console.log(gameIDs);
+    }
+  });
+
+  // communicates with Game 
   socket.on('setroom', function(roomID) {
-    socket.room = "room" + roomID;
+    socket.room = "room " + roomID;
     if (roomID in data) { // room has been entered before 
       if (data[roomID]["atCapacity"]) {
         socket.emit('fullhouse');


### PR DESCRIPTION
After user creates a new game or joins a new game from the homepage. They will now see a role selection menu 

<img width="419" alt="screen shot 2017-03-04 at 1 11 35 am" src="https://cloud.githubusercontent.com/assets/8050723/23576580/928c8640-0077-11e7-99d5-e6e7552ab3ac.png">

Users will be able to select either a student, teacher or observer role. Since there is only one teacher and one student per game, if that option has already been selected previously then the radio button for that option will be inactive. 

One they click on Enter Game, they will see the game instance:
<img width="1186" alt="screen shot 2017-03-04 at 1 13 26 am" src="https://cloud.githubusercontent.com/assets/8050723/23576585/cbee6bd8-0077-11e7-877b-4c682d215e25.png">

Instead of entering their usernames, the chat will display their role when a new message is sent. 

<img width="1186" alt="screen shot 2017-03-04 at 1 13 26 am" src="https://cloud.githubusercontent.com/assets/8050723/23580291/654389d6-00cc-11e7-97af-2816020a1eb1.png">
