### PR TITLE
Fix version of extract-text-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "express": "^4.14.0",
-    "extract-text-webpack-plugin": "",
+    "extract-text-webpack-plugin": "1.0.1",
     "mongoose": "",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",


### PR DESCRIPTION
The `extract-text-webpack-plugin` version was not set in `package.json` and it looks like they released a new version recently.  That new version required a more recent version of Webpack as a peer dependency, and there were incompatibilities.

This fixes the version to be the old version, and separately it'd be good to update Webpack and all the dependencies here (and separately to switch to a "build" step for the JS).

FWIW, to track this down I looked at the Heroku logs:
```
2017-03-29T00:00:00.179130+00:00 app[web.1]: /app/node_modules/extract-text-webpack-plugin/index.js:267
2017-03-29T00:00:00.179144+00:00 app[web.1]: 				var shouldExtract = !!(options.allChunks || chunk.isInitial());
2017-03-29T00:00:00.179144+00:00 app[web.1]: 				                                                  ^
2017-03-29T00:00:00.179145+00:00 app[web.1]:
2017-03-29T00:00:00.179146+00:00 app[web.1]: TypeError: chunk.isInitial is not a function
```

And then googled that error to see what was around.

Let's see if this helps!